### PR TITLE
Google api service, closes #4, closes #12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ coverage
 
 # Ignore application configuration
 /config/application.yml
+
+/spec/fixtures

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
+gem 'faraday'
 gem 'figaro'
 
 group :development, :test do
@@ -46,6 +47,11 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+end
+
+group :test do
+  gem 'vcr'
+  gem 'webmock'
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     bootsnap (1.3.2)
       msgpack (~> 1.0)
@@ -49,6 +51,8 @@ GEM
     byebug (10.0.2)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.4)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
@@ -59,11 +63,14 @@ GEM
     factory_bot_rails (4.11.1)
       factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
+    faraday (0.15.2)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
     figaro (1.1.1)
       thor (~> 0.14)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    hashdiff (0.3.7)
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
@@ -84,6 +91,7 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     msgpack (1.2.4)
+    multipart-post (2.0.0)
     nio4r (2.3.1)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
@@ -91,6 +99,7 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.5)
     rack-test (1.1.0)
@@ -141,6 +150,7 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
     ruby_dep (1.5.0)
+    safe_yaml (1.0.4)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
     simplecov (0.16.1)
@@ -164,6 +174,11 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    vcr (4.0.0)
+    webmock (3.4.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -177,6 +192,7 @@ DEPENDENCIES
   byebug
   database_cleaner
   factory_bot_rails
+  faraday
   figaro
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
@@ -189,6 +205,8 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
+  vcr
+  webmock
 
 RUBY VERSION
    ruby 2.5.0p0

--- a/app/services/google_directions_service.rb
+++ b/app/services/google_directions_service.rb
@@ -1,0 +1,38 @@
+class GoogleDirectionsService
+  def initialize(start_address, end_address, departure_time = nil)
+    @start_address = start_address
+    @end_address = end_address
+    @departure_time = departure_time
+  end
+
+  def trip_information
+    raw_info[:routes][0][:legs][0]
+  end
+
+  private
+    attr_reader :start_address, :end_address, :departure_time
+
+    def conn
+      Faraday.new(url: "https://maps.googleapis.com/maps/api/directions/json")
+    end
+
+    def request_trip_info
+      conn.get do |req|
+        req.params['origin'] = start_address
+        req.params['destination'] = end_address
+        req.params['mode'] = 'transit'
+        req.params['key'] = ENV['google_directions_api_key']
+        if !departure_time.nil?
+          req.params['departure_time'] = departure_time
+        end
+      end
+    end
+
+    def response
+      @response ||= request_trip_info
+    end
+
+    def raw_info
+      JSON.parse(response.body, symbolize_names: true)
+    end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,15 @@ require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
+require 'webmock/rspec'
+
+VCR.configure do |config|
+  config.cassette_library_dir = "spec/fixtures/cassettes"
+  config.hook_into :webmock
+  config.filter_sensitive_data("<google_directions_api_key>") { ENV["google_directions_api_key"] }
+  config.configure_rspec_metadata!
+end
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 require 'simplecov'

--- a/spec/services/google_api_service_spec.rb
+++ b/spec/services/google_api_service_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe GoogleDirectionsService do
+  subject { GoogleDirectionsService.new(
+    "12+Cedar+Pl+Denver+CO",
+    "1331+17th+St+Denver+CO",
+    1536686679
+  ) }
+
+  it 'exists' do
+    expect(subject).to be_a GoogleDirectionsService
+  end
+
+  context 'instance methods' do
+    context '.trip_information' do
+      it 'returns an an object that contains and array of each "step" of a trip' do
+        raw_search = subject.trip_information
+
+        expect(raw_search).to have_key :arrival_time
+        expect(raw_search).to have_key :departure_time
+        expect(raw_search).to have_key :distance
+        expect(raw_search).to have_key :duration
+        expect(raw_search).to have_key :end_address
+        expect(raw_search).to have_key :start_address
+        expect(raw_search).to have_key :steps
+        expect(raw_search['steps'][1]).to have_key :distance
+        expect(raw_search['steps'][1]).to have_key :duration
+        expect(raw_search['steps'][1]).to have_key :html_instructions
+        expect(raw_search['steps'][1]).to have_key :transit_details
+        expect(raw_search['steps'][1]).to have_key :travel_mode
+        expect(raw_search['steps'][1]['transit_details']).to have_key :arrival_stop
+        expect(raw_search['steps'][1]['transit_details']).to have_key :arrival_time
+        expect(raw_search['steps'][1]['transit_details']).to have_key :departure_time
+        expect(raw_search['steps'][1]['transit_details']).to have_key :headsign
+        expect(raw_search['steps'][1]['transit_details']).to have_key :line
+        expect(raw_search['steps'][1]['transit_details']).to have_key :num_stops
+        expect(raw_search['steps'][1]['transit_details']['line']).to have_key :agencies
+        expect(raw_search['steps'][1]['transit_details']['line']).to have_key :color
+        expect(raw_search['steps'][1]['transit_details']['line']).to have_key :name
+        expect(raw_search['steps'][1]['transit_details']['line']).to have_key :short_name
+        expect(raw_search['steps'][1]['transit_details']['line']).to have_key :vehicle
+        expect(raw_search['steps'][1]['transit_details']['line']['vehicle']).to have_key :name
+      end
+    end
+  end
+end

--- a/spec/services/google_api_service_spec.rb
+++ b/spec/services/google_api_service_spec.rb
@@ -4,7 +4,7 @@ describe GoogleDirectionsService do
   subject { GoogleDirectionsService.new(
     "12+Cedar+Pl+Denver+CO",
     "1331+17th+St+Denver+CO",
-    1536686679
+    1536692079
   ) }
 
   it 'exists' do
@@ -13,7 +13,7 @@ describe GoogleDirectionsService do
 
   context 'instance methods' do
     context '.trip_information' do
-      it 'returns an an object that contains and array of each "step" of a trip' do
+      it 'returns an object that contains an array of each "step" of a trip', vcr: true do
         raw_search = subject.trip_information
 
         expect(raw_search).to have_key :arrival_time
@@ -23,23 +23,23 @@ describe GoogleDirectionsService do
         expect(raw_search).to have_key :end_address
         expect(raw_search).to have_key :start_address
         expect(raw_search).to have_key :steps
-        expect(raw_search['steps'][1]).to have_key :distance
-        expect(raw_search['steps'][1]).to have_key :duration
-        expect(raw_search['steps'][1]).to have_key :html_instructions
-        expect(raw_search['steps'][1]).to have_key :transit_details
-        expect(raw_search['steps'][1]).to have_key :travel_mode
-        expect(raw_search['steps'][1]['transit_details']).to have_key :arrival_stop
-        expect(raw_search['steps'][1]['transit_details']).to have_key :arrival_time
-        expect(raw_search['steps'][1]['transit_details']).to have_key :departure_time
-        expect(raw_search['steps'][1]['transit_details']).to have_key :headsign
-        expect(raw_search['steps'][1]['transit_details']).to have_key :line
-        expect(raw_search['steps'][1]['transit_details']).to have_key :num_stops
-        expect(raw_search['steps'][1]['transit_details']['line']).to have_key :agencies
-        expect(raw_search['steps'][1]['transit_details']['line']).to have_key :color
-        expect(raw_search['steps'][1]['transit_details']['line']).to have_key :name
-        expect(raw_search['steps'][1]['transit_details']['line']).to have_key :short_name
-        expect(raw_search['steps'][1]['transit_details']['line']).to have_key :vehicle
-        expect(raw_search['steps'][1]['transit_details']['line']['vehicle']).to have_key :name
+        expect(raw_search[:steps][1]).to have_key :distance
+        expect(raw_search[:steps][1]).to have_key :duration
+        expect(raw_search[:steps][1]).to have_key :html_instructions
+        expect(raw_search[:steps][1]).to have_key :transit_details
+        expect(raw_search[:steps][1]).to have_key :travel_mode
+        expect(raw_search[:steps][1][:transit_details]).to have_key :arrival_stop
+        expect(raw_search[:steps][1][:transit_details]).to have_key :arrival_time
+        expect(raw_search[:steps][1][:transit_details]).to have_key :departure_time
+        expect(raw_search[:steps][1][:transit_details]).to have_key :headsign
+        expect(raw_search[:steps][1][:transit_details]).to have_key :line
+        expect(raw_search[:steps][1][:transit_details]).to have_key :num_stops
+        expect(raw_search[:steps][1][:transit_details][:line]).to have_key :agencies
+        expect(raw_search[:steps][1][:transit_details][:line]).to have_key :color
+        expect(raw_search[:steps][1][:transit_details][:line]).to have_key :name
+        expect(raw_search[:steps][1][:transit_details][:line]).to have_key :short_name
+        expect(raw_search[:steps][1][:transit_details][:line]).to have_key :vehicle
+        expect(raw_search[:steps][1][:transit_details][:line][:vehicle]).to have_key :name
       end
     end
   end


### PR DESCRIPTION
#### Changes Proposed:
* Adds test with fixtures for using Google Directions Service.
* Adds Google Directions service that uses Faraday to make connection to API.
* Google Directions Service currently expects start_address and end_address to come in as the manufactured string with + signs in between words, and it expects departure_time to come in as an integer representing the number of seconds between Jan 1, 1970 and the requested time.  It may become necessary to add parsing methods to this service to facilitate passing in the information.

#### Fixes Made:
* n/a
#### Testing:
* Tested on RSPEC? Yes
* All tests passing? Yes
#### Mentions:
@jamisonordway Do you think it's worth adding parsing methods to the service regarding the incoming strings and integer, or do you think we should wait and see if we should accomplish that elsewhere?
