### PR TITLE
Get itineraries endpoint, closes #30

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'database_cleaner'
-  gem 'factory_bot_rails'
+  gem 'factory_bot_rails', "~> 4.0"
   gem 'pry'
   gem 'rspec-rails'
   gem 'shoulda-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,7 +200,7 @@ DEPENDENCIES
   bundler
   byebug
   database_cleaner
-  factory_bot_rails
+  factory_bot_rails (~> 4.0)
   faraday
   figaro
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/api/v1/users/itineraries_controller.rb
+++ b/app/controllers/api/v1/users/itineraries_controller.rb
@@ -7,6 +7,11 @@ class Api::V1::Users::ItinerariesController < ApiController
     render json: possible_route
   end
 
+  def index
+    user = User.find_by(id: params[:id])
+    render json: user.possible_routes
+  end
+
   private
 
     def itinerary_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   has_many :itineraries
+  has_many :possible_routes, through: :itineraries
   validates :email, presence: true
   validates :uid, presence: true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
       post '/users', to: 'users#create'
       namespace :users do
         get '/:id/favorite_itineraries', to: 'favorite_itineraries#index'
+        get '/:id/itineraries', to: 'itineraries#index'
         post '/:id/itineraries', to: 'itineraries#create'
       end
     end

--- a/spec/factories/itineraries.rb
+++ b/spec/factories/itineraries.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :itinerary do
+    start_address { "12 Cedar Pl, Denver, CO"}
+    end_address { "1331 17th St, Denver, CO"}
+    user
+  end
+end

--- a/spec/factories/possible_routes.rb
+++ b/spec/factories/possible_routes.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :possible_route do
+    departure_time { "11:35am" }
+    arrival_time { "12:45pm" }
+    duration { "1 hour 10 mins" }
+    distance { "10 mi" }
+    itinerary
+  end
+end

--- a/spec/factories/steps.rb
+++ b/spec/factories/steps.rb
@@ -1,0 +1,21 @@
+FactoryBot.define do
+  factory :step do
+    distance { "1 mi" }
+    duration { "10 mins" }
+    instructions { "Take the bus" }
+    headsign { "Union Station" }
+    arrival_time { '12:00pm' }
+    departure_time { '11:50am' }
+    arrival_stop { '18th St & Market St' }
+    departure_stop { 'Lowry Blvd & Rampart Way' }
+    name { 'Union Station' }
+    short_name { '6' }
+    color { '#FFFFFF' }
+    credit_name { 'Regional Transportation District' }
+    credit_url { 'http://rtd-denver.com' }
+    vehicle_type { 'Bus' }
+    num_stops { '32' }
+    travel_mode { 'TRANSIT' }
+    possible_route
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user do
+    email { "example2@example.com" }
+    uid { 2 }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 require 'webmock/rspec'
+require 'support/factory_bot'
 
 VCR.configure do |config|
   config.cassette_library_dir = "spec/fixtures/cassettes"

--- a/spec/requests/api/v1/favorite_itineraries/user_can_get_favorite_locations_spec.rb
+++ b/spec/requests/api/v1/favorite_itineraries/user_can_get_favorite_locations_spec.rb
@@ -4,7 +4,7 @@ describe 'Favorite Itineraries API' do
   it 'sends JSON of the user\'s favorite itineraries' do
     get '/api/v1/users/1/favorite_itineraries'
 
-    expect(response).to be_success
+    expect(response).to be_successful
 
     expected = [
       {

--- a/spec/requests/api/v1/itineraries/get_itineraries_endpoint_spec.rb
+++ b/spec/requests/api/v1/itineraries/get_itineraries_endpoint_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe 'GET /api/v1/users/:id/itineraries' do
+  it 'should return all itineraries that a user has searched for' do
+    user = create(:user)
+    itinerary1 = create(:itinerary, user_id: user.id)
+    itinerary2 = create(:itinerary, user_id: user.id)
+    possible_route1 = create(:possible_route, itinerary_id: itinerary1.id)
+    possible_route2 = create(:possible_route, itinerary_id: itinerary2.id)
+    step1 = create(:step, possible_route_id: possible_route1.id)
+    step2 = create(:step, possible_route_id: possible_route1.id)
+    step3 = create(:step, possible_route_id: possible_route2.id)
+    step4 = create(:step, possible_route_id: possible_route2.id)
+
+    get "/api/v1/users/#{user.id}/itineraries"
+
+    expect(response).to be_successful
+    itineraries = JSON.parse(response.body, symbolize_names: true)
+    expect(itineraries.length).to eq(2)
+    expect(itineraries[0][:steps].length).to eq(2)
+    expect(itineraries[1][:steps].length).to eq(2)
+  end
+end

--- a/spec/requests/api/v1/itineraries/post_itinerary_endpoint_spec.rb
+++ b/spec/requests/api/v1/itineraries/post_itinerary_endpoint_spec.rb
@@ -7,7 +7,7 @@ describe 'POST /api/v1/users/:id/itineraries' do
 
     post "/api/v1/users/#{user.id}/itineraries", params: { start_address: "100 W 14th Ave Pkwy Denver CO 80204", end_address: "1331 17th St Denver CO", departure_time: '17:00'}
 
-    expect(response).to be_success
+    expect(response).to be_successful
 
     new_itinerary = JSON.parse(response.body, symbolize_names: true)
     expect(new_itinerary[0][:steps].length).to eq(3)
@@ -19,7 +19,7 @@ describe 'POST /api/v1/users/:id/itineraries' do
 
     post "/api/v1/users/#{user.id}/itineraries", params: { start_address: "100 W 14th Ave Pkwy Denver CO 80204", end_address: "1331 17th St Denver CO", arrival_time: '17:00'}
 
-    expect(response).to be_success
+    expect(response).to be_successful
 
     new_itinerary = JSON.parse(response.body, symbolize_names: true)
     expect(new_itinerary[0][:steps].length).to eq(3)

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end


### PR DESCRIPTION
#### Changes Proposed:
* Adds Factories to clean up tests
* Adds has_many :possible_routes, through: :itineraries to User model to enable us to call user.possible_routes in the controller
* Adds route and controller action for GET /api/v1/users/:id/itineraries

#### Fixes Made:
* Changes be_success to be_successful to get rid of deprecation warnings.

#### Testing:
* Tested on RSPEC? Yes
* All tests passing? Yes

#### Mentions:
@jamisonordway The hardest part of this feature was getting factory bot to work.  Have we always needed to require the support/factory_bot.rb file in the rails_helper in order to get it to perceive the factory_bot methods?
