### PR TITLE
Adds GET /users/:uid endpoint, closes #37

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -5,6 +5,10 @@ class Api::V1::UsersController < ApplicationController
     render json: user
   end
 
+  def show
+    user = User.find_by(uid: params[:uid])
+    render json: user
+  end
 
   private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   has_many :itineraries
   has_many :possible_routes, through: :itineraries
+  validates :username, presence: true
   validates :email, presence: true
-  validates :uid, presence: true
+  validates :uid, presence: true, uniqueness: true
 end

--- a/app/serializers/possible_route_serializer.rb
+++ b/app/serializers/possible_route_serializer.rb
@@ -1,6 +1,7 @@
 class PossibleRouteSerializer < ActiveModel::Serializer
-  attributes :itinerary_id, :start_address, :end_address, :favorite, :departure_time, :arrival_time, :duration, :distance
-  has_many :steps
+  attributes  :itinerary_id, :start_address, :end_address,
+              :favorite, :departure_time, :arrival_time,
+              :duration, :distance, :steps
 
   def favorite
     object.itinerary.favorite
@@ -16,5 +17,9 @@ class PossibleRouteSerializer < ActiveModel::Serializer
 
   def end_address
     object.itinerary.end_address
+  end
+
+  def steps
+    object.steps.order("id ASC")
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       post '/users', to: 'users#create'
+      get '/users/:uid', to: 'users#show'
       namespace :users do
         get '/:id/favorite_itineraries', to: 'favorite_itineraries#index'
         get '/:id/itineraries', to: 'itineraries#index'

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :user do
+    username { 'boobooo' }
     email { "example2@example.com" }
     uid { 2 }
   end

--- a/spec/requests/api/v1/itineraries/post_itinerary_endpoint_spec.rb
+++ b/spec/requests/api/v1/itineraries/post_itinerary_endpoint_spec.rb
@@ -4,108 +4,14 @@ describe 'POST /api/v1/users/:id/itineraries' do
   it 'accepts json of start_address, end_address, and departure_time', vcr: true do
     user = create(:user)
 
-    expected = [
-    {
-        "itinerary_id": 1,
-        "start_address": "100 W 14th Ave Pkwy, Denver, CO 80203, USA",
-        "end_address": "Denver International Airport (DEN), 8500 Peña Blvd, Denver, CO 80249, USA",
-        "favorite": false,
-        "departure_time": "5:02pm",
-        "arrival_time": "6:07pm",
-        "duration": "1 hour 4 mins",
-        "distance": "25.1 mi",
-        "steps": [
-            {
-                "id": 1,
-                "possible_route_id": 1,
-                "headsign": nil,
-                "arrival_time": nil,
-                "departure_time": nil,
-                "arrival_stop": nil,
-                "departure_stop": nil,
-                "name": nil,
-                "short_name": nil,
-                "instructions": "Walk to Colfax Ave & Broadway",
-                "distance": "0.2 mi",
-                "duration": "5 mins",
-                "color": nil,
-                "num_stops": nil,
-                "vehicle_type": nil,
-                "credit_name": nil,
-                "credit_url": nil,
-                "travel_mode": "Walking"
-            },
-            {
-                "id": 2,
-                "possible_route_id": 1,
-                "headsign": "Union Station Downtown",
-                "arrival_time": "5:20pm",
-                "departure_time": "5:08pm",
-                "arrival_stop": "Union Station",
-                "departure_stop": "Colfax Ave & Broadway",
-                "name": "East Colfax Avenue",
-                "short_name": "15",
-                "instructions": "Bus towards Union Station Downtown",
-                "distance": "1.5 mi",
-                "duration": "12 mins",
-                "color": "#0277bd",
-                "num_stops": 8,
-                "vehicle_type": "Bus",
-                "credit_name": "Regional Transportation District",
-                "credit_url": "http://rtd-denver.com/",
-                "travel_mode": "TRANSIT"
-            },
-            {
-                "id": 3,
-                "possible_route_id": 1,
-                "headsign": nil,
-                "arrival_time": nil,
-                "departure_time": nil,
-                "arrival_stop": nil,
-                "departure_stop": nil,
-                "name": nil,
-                "short_name": nil,
-                "instructions": "Walk to Union Station",
-                "distance": "0.1 mi",
-                "duration": "3 mins",
-                "color": nil,
-                "num_stops": nil,
-                "vehicle_type": nil,
-                "credit_name": nil,
-                "credit_url": nil,
-                "travel_mode": "Walking"
-            },
-            {
-                "id": 4,
-                "possible_route_id": 1,
-                "headsign": "Denver Airport",
-                "arrival_time": "6:07pm",
-                "departure_time": "5:30pm",
-                "arrival_stop": "Denver Airport Station",
-                "departure_stop": "Union Station",
-                "name": "Union Station to Denver Airport Station",
-                "short_name": "A",
-                "instructions": "Train towards Denver Airport",
-                "distance": "23.3 mi",
-                "duration": "37 mins",
-                "color": "#4fc3f7",
-                "num_stops": 7,
-                "vehicle_type": "Train",
-                "credit_name": "Regional Transportation District",
-                "credit_url": "http://rtd-denver.com/",
-                "travel_mode": "TRANSIT"
-            }
-        ]
-    }
-]
-
     post "/api/v1/users/#{user.id}/itineraries", params: { start_address: "100 W 14th Ave Pkwy Denver CO 80204", end_address: "Denver International Airport", departure_time: '17:00' }
 
     expect(response).to be_successful
 
     new_itinerary = JSON.parse(response.body, symbolize_names: true)
     expect(new_itinerary[0][:steps].length).to eq(4)
-    expect(new_itinerary).to eq(expected)
+    expect(new_itinerary[0][:steps].first[:id]).to eq(1)
+    expect(new_itinerary[0][:steps].last[:id]).to eq(4)
   end
 
   it 'also accepts json including arrival time', vcr: true do

--- a/spec/requests/api/v1/itineraries/post_itinerary_endpoint_spec.rb
+++ b/spec/requests/api/v1/itineraries/post_itinerary_endpoint_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'POST /api/v1/users/:id/itineraries' do
   it 'accepts json of start_address, end_address, and departure_time', vcr: true do
-    user = User.create(email: 'example@example.com', uid: '1')
+    user = create(:user)
 
     expected = [
     {
@@ -109,7 +109,7 @@ describe 'POST /api/v1/users/:id/itineraries' do
   end
 
   it 'also accepts json including arrival time', vcr: true do
-    user = User.create(email: 'example@example.com', uid: '1')
+    user = create(:user)
 
 
     post "/api/v1/users/#{user.id}/itineraries", params: { start_address: "100 W 14th Ave Pkwy Denver CO 80204", end_address: "1331 17th St Denver CO", arrival_time: '17:00'}

--- a/spec/requests/api/v1/itineraries/post_itinerary_endpoint_spec.rb
+++ b/spec/requests/api/v1/itineraries/post_itinerary_endpoint_spec.rb
@@ -4,13 +4,108 @@ describe 'POST /api/v1/users/:id/itineraries' do
   it 'accepts json of start_address, end_address, and departure_time', vcr: true do
     user = User.create(email: 'example@example.com', uid: '1')
 
+    expected = [
+    {
+        "itinerary_id": 1,
+        "start_address": "100 W 14th Ave Pkwy, Denver, CO 80203, USA",
+        "end_address": "Denver International Airport (DEN), 8500 Peña Blvd, Denver, CO 80249, USA",
+        "favorite": false,
+        "departure_time": "5:02pm",
+        "arrival_time": "6:07pm",
+        "duration": "1 hour 4 mins",
+        "distance": "25.1 mi",
+        "steps": [
+            {
+                "id": 1,
+                "possible_route_id": 1,
+                "headsign": nil,
+                "arrival_time": nil,
+                "departure_time": nil,
+                "arrival_stop": nil,
+                "departure_stop": nil,
+                "name": nil,
+                "short_name": nil,
+                "instructions": "Walk to Colfax Ave & Broadway",
+                "distance": "0.2 mi",
+                "duration": "5 mins",
+                "color": nil,
+                "num_stops": nil,
+                "vehicle_type": nil,
+                "credit_name": nil,
+                "credit_url": nil,
+                "travel_mode": "Walking"
+            },
+            {
+                "id": 2,
+                "possible_route_id": 1,
+                "headsign": "Union Station Downtown",
+                "arrival_time": "5:20pm",
+                "departure_time": "5:08pm",
+                "arrival_stop": "Union Station",
+                "departure_stop": "Colfax Ave & Broadway",
+                "name": "East Colfax Avenue",
+                "short_name": "15",
+                "instructions": "Bus towards Union Station Downtown",
+                "distance": "1.5 mi",
+                "duration": "12 mins",
+                "color": "#0277bd",
+                "num_stops": 8,
+                "vehicle_type": "Bus",
+                "credit_name": "Regional Transportation District",
+                "credit_url": "http://rtd-denver.com/",
+                "travel_mode": "TRANSIT"
+            },
+            {
+                "id": 3,
+                "possible_route_id": 1,
+                "headsign": nil,
+                "arrival_time": nil,
+                "departure_time": nil,
+                "arrival_stop": nil,
+                "departure_stop": nil,
+                "name": nil,
+                "short_name": nil,
+                "instructions": "Walk to Union Station",
+                "distance": "0.1 mi",
+                "duration": "3 mins",
+                "color": nil,
+                "num_stops": nil,
+                "vehicle_type": nil,
+                "credit_name": nil,
+                "credit_url": nil,
+                "travel_mode": "Walking"
+            },
+            {
+                "id": 4,
+                "possible_route_id": 1,
+                "headsign": "Denver Airport",
+                "arrival_time": "6:07pm",
+                "departure_time": "5:30pm",
+                "arrival_stop": "Denver Airport Station",
+                "departure_stop": "Union Station",
+                "name": "Union Station to Denver Airport Station",
+                "short_name": "A",
+                "instructions": "Train towards Denver Airport",
+                "distance": "23.3 mi",
+                "duration": "37 mins",
+                "color": "#4fc3f7",
+                "num_stops": 7,
+                "vehicle_type": "Train",
+                "credit_name": "Regional Transportation District",
+                "credit_url": "http://rtd-denver.com/",
+                "travel_mode": "TRANSIT"
+            }
+        ]
+    }
+]
 
-    post "/api/v1/users/#{user.id}/itineraries", params: { start_address: "100 W 14th Ave Pkwy Denver CO 80204", end_address: "1331 17th St Denver CO", departure_time: '17:00'}
+    post "/api/v1/users/#{user.id}/itineraries", params: { start_address: "100 W 14th Ave Pkwy Denver CO 80204", end_address: "Denver International Airport", departure_time: '17:00' }
 
     expect(response).to be_successful
 
     new_itinerary = JSON.parse(response.body, symbolize_names: true)
-    expect(new_itinerary[0][:steps].length).to eq(3)
+    expect(new_itinerary[0][:steps].length).to eq(4)
+    expect(new_itinerary).to eq(expected)
   end
 
   it 'also accepts json including arrival time', vcr: true do

--- a/spec/requests/api/v1/users/get_user_spec.rb
+++ b/spec/requests/api/v1/users/get_user_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe 'GET /users/:uid' do
+  it 'should be able to return a user by uid' do
+    user = create(:user, uid: 'abc123')
+
+    get "/api/v1/users/#{user.uid}"
+
+    expect(response).to be_successful
+
+    new_user = JSON.parse(response.body, symbolize_names: true)
+    expect(new_user[:username]).to eq(user.username)
+    expect(new_user[:email]).to eq(user.email)
+    expect(new_user[:uid]).to eq('abc123')
+  end
+end


### PR DESCRIPTION
#### Changes Proposed:
* Adds GET /users/:uid endpoint

#### Fixes Made:
* Updates user factory
* Updates possible routes serializer to arrange the steps in ascending order

#### Testing:
* Tested on RSPEC? YES
* All tests passing? YES

#### Mentions:
@jamisonordway I did a workaround to get the serializer to output the steps in the order we want. Not sure what the preferred way of testing serializers is, but our coverage file doesn't really think that the serializers are tested...