### PR TITLE
Multiple api calls

### DIFF
--- a/app/controllers/api/v1/users/itineraries_controller.rb
+++ b/app/controllers/api/v1/users/itineraries_controller.rb
@@ -5,8 +5,11 @@ class Api::V1::Users::ItinerariesController < ApiController
     @new_itinerary = CreateWholeTrip.new(user.id, itinerary_params)
     @new_itinerary.create_steps
     itinerary = @new_itinerary.itinerary
-    possible_route = itinerary.possible_routes
-    render json: possible_route
+    base_time = itinerary.possible_routes[0].departure_time
+    CreateOtherPossibleRoute.new(itinerary.id, itinerary_params, base_time, 15).create_steps
+    possible_routes = itinerary.possible_routes
+    updated_itinerary = Itinerary.find(itinerary.id)
+    render json: updated_itinerary.possible_routes
   end
 
   def index
@@ -17,6 +20,6 @@ class Api::V1::Users::ItinerariesController < ApiController
   private
 
     def itinerary_params
-      params.permit(:id, :start_address, :end_address, :departure_time, :arrival_time)
+      params.permit(:uid, :start_address, :end_address, :departure_time, :arrival_time)
     end
 end

--- a/app/models/create_other_possible_route.rb
+++ b/app/models/create_other_possible_route.rb
@@ -1,0 +1,51 @@
+class CreateOtherPossibleRoute < CreateWholeTrip
+  attr_reader :itinerary_id, :base_time, :additional_time, :departure_time
+
+  def initialize(itinerary_id, attrs, base_time, additional_time)
+    @itinerary_id = itinerary_id
+    @start_address = attrs[:start_address]
+    @end_address = attrs[:end_address]
+    @base_time = base_time
+    @additional_time = additional_time
+    @departure_time = get_new_time
+    @possible_route = create_possible_route
+  end
+
+  def create_possible_route
+    PossibleRoute.create(
+      itinerary_id: itinerary_id,
+      duration: itinerary_attrs[:duration][:text],
+      distance: itinerary_attrs[:distance][:text],
+      departure_time: itinerary_attrs[:departure_time][:text],
+      arrival_time: itinerary_attrs[:arrival_time][:text]
+    )
+  end
+
+  def get_new_time
+    split_times = base_time.delete('apm').split(':')
+    hours = split_times.first.to_i
+    minutes = split_times[1].to_i
+    if base_time.include?('pm') && hours < 12
+      new_hours = (hours + 12).to_s
+    elsif base_time.include?('am') && hours == 12
+      new_hours = '0'
+    elsif base_time.include?('pm') && hours == 12
+      new_hours = '12'
+    elsif base_time.include?('am') && hours < 12
+      new_hours = hours.to_s
+    end
+    new_minutes = (minutes + additional_time).to_s
+    new_hours + ':' + new_minutes
+  end
+
+  private
+    attr_reader :start_address, :end_address
+
+    def service
+      @service ||= GoogleDirectionsService.new(
+        start_address,
+        end_address,
+        departure_time
+      )
+    end
+end

--- a/app/models/create_whole_trip.rb
+++ b/app/models/create_whole_trip.rb
@@ -1,7 +1,6 @@
 class CreateWholeTrip
   attr_reader :user_id, :itinerary, :possible_route
   def initialize(user_id, attrs)
-    # binding.pry
     @user_id = user_id
     @start_address = attrs[:start_address]
     @end_address = attrs[:end_address]

--- a/app/serializers/possible_route_serializer.rb
+++ b/app/serializers/possible_route_serializer.rb
@@ -1,7 +1,7 @@
 class PossibleRouteSerializer < ActiveModel::Serializer
   attributes  :itinerary_id, :start_address, :end_address,
               :favorite, :departure_time, :arrival_time,
-              :duration, :distance, :steps, :title
+              :duration, :distance, :title, :steps
 
   def favorite
     object.itinerary.favorite

--- a/app/serializers/step_serializer.rb
+++ b/app/serializers/step_serializer.rb
@@ -1,20 +1,6 @@
 class StepSerializer < ActiveModel::Serializer
-  attributes  :id,
-              :headsign,
-              :short_name,
-              :name,
-              :distance,
-              :duration,
-              :arrival_time,
-              :departure_time,
-              :arrival_stop,
-              :departure_stop,
-              :instructions,
-              :color,
-              :vehicle_type,
-              :credit_name,
-              :credit_url,
-              :instructions,
-              :travel_mode,
-              :num_stops
+  attributes  :id, :headsign, :short_name, :name, :distance, :duration,
+              :arrival_time, :departure_time, :arrival_stop, :departure_stop,
+              :instructions, :color, :vehicle_type, :credit_name, :credit_url,
+              :instructions, :travel_mode, :num_stops
 end

--- a/spec/models/create_other_possible_route_spec.rb
+++ b/spec/models/create_other_possible_route_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+describe CreateOtherPossibleRoute do
+  context 'instance methods' do
+    context '.get_new_time' do
+      it 'should get new time based on 12am', vcr: true do
+        itinerary = create(:itinerary)
+        base_time = "12:00am"
+        itinerary_params = {
+          start_address: '12 Cedar Pl, Denver, CO 80230',
+          end_address: '1331 17th St, Denver, CO 80230'}
+
+        new_route = CreateOtherPossibleRoute.new(itinerary.id, itinerary_params, base_time, 15)
+        expect(new_route.departure_time).to eq("0:15")
+      end
+
+      it 'should get new time based on 12pm', vcr: true do
+        itinerary = create(:itinerary)
+        base_time = "12:00pm"
+        itinerary_params = {
+          start_address: '12 Cedar Pl, Denver, CO 80230',
+          end_address: '1331 17th St, Denver, CO 80230'}
+
+        new_route = CreateOtherPossibleRoute.new(itinerary.id, itinerary_params, base_time, 15)
+        expect(new_route.departure_time).to eq("12:15")
+      end
+
+      it 'should get new time based on 6am', vcr: true do
+        itinerary = create(:itinerary)
+        base_time = "6:00am"
+        itinerary_params = {
+          start_address: '12 Cedar Pl, Denver, CO 80230',
+          end_address: '1331 17th St, Denver, CO 80230'}
+
+        new_route = CreateOtherPossibleRoute.new(itinerary.id, itinerary_params, base_time, 15)
+        expect(new_route.departure_time).to eq("6:15")
+      end
+
+      it 'should get new time based on 5pm', vcr: true do
+        itinerary = create(:itinerary)
+        base_time = "5:00pm"
+        itinerary_params = {
+          start_address: '12 Cedar Pl, Denver, CO 80230',
+          end_address: '1331 17th St, Denver, CO 80230'}
+
+        new_route = CreateOtherPossibleRoute.new(itinerary.id, itinerary_params, base_time, 15)
+        expect(new_route.departure_time).to eq("17:15")
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/itineraries/post_itinerary_endpoint_spec.rb
+++ b/spec/requests/api/v1/itineraries/post_itinerary_endpoint_spec.rb
@@ -17,12 +17,24 @@ describe 'POST /api/v1/users/:id/itineraries' do
   it 'also accepts json including arrival time', vcr: true do
     user = create(:user, uid: 'abc123')
 
-
     post "/api/v1/users/#{user.uid}/itineraries", params: { start_address: "100 W 14th Ave Pkwy Denver CO 80204", end_address: "1331 17th St Denver CO", arrival_time: '17:00'}
 
     expect(response).to be_successful
 
     new_itinerary = JSON.parse(response.body, symbolize_names: true)
     expect(new_itinerary[0][:steps].length).to eq(3)
+  end
+
+  it 'returns multiple possible routes for one itinerary', vcr: true do
+    user = create(:user, uid: 'abc123')
+
+    post "/api/v1/users/#{user.uid}/itineraries", params: { start_address: "661 Logan St, Denver, CO 80203", end_address: "750 North Colorado Boulevard, Denver, CO 80206", departure_time: '17:00'}
+
+    expect(response).to be_successful
+
+    new_itineraries = JSON.parse(response.body, symbolize_names:true)
+    expect(new_itineraries.length).to eq(2)
+    expect(new_itineraries[0][:departure_time]).to eq("5:06pm")
+    expect(new_itineraries[1][:departure_time]).to eq("5:21pm")
   end
 end

--- a/spec/requests/api/v1/users/create_user_spec.rb
+++ b/spec/requests/api/v1/users/create_user_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'POST /api/v1/users' do
+  it 'should be able to create a user and return a user JSON object' do
+    post '/api/v1/users', params: { username: 'booboooo', email: 'yes@ayeaye.com', uid: '123abc' }
+
+    expect(response).to be_successful
+
+    user = JSON.parse(response.body, symbolize_names: true)
+
+    expect(user[:username]).to eq('booboooo')
+    expect(user[:email]).to eq('yes@ayeaye.com')
+    expect(user[:uid]).to eq('123abc')
+  end
+end


### PR DESCRIPTION
#### Changes Proposed:
* Adds Create Other Possible Route model, which takes as one of its arguments the amount of time you want to add to the previous route's departure time.
* Updates itineraries create action to make the second api call and the test to ensure that we receive two possible routes.

#### Fixes Made:
* Adds create user endpoint test.
* Adjusts possible route serializer so that the title comes before the steps.

#### Testing:
* Tested on RSPEC? Yes
* All tests passing? Yes

#### Mentions:
@jamisonordway This was a tricky one! Inheritance worked well for the new Create Other Possible Routes model though.  I'm thinking the next step is to add an intermediary model that takes the number of api calls we want to make as an argument, and then that model calls the Create Other Possible Routes model that many times, incrementing its 'additional_time' parameter each time.