### PR TITLE
Sequential calls poro, closes #36

### DIFF
--- a/app/controllers/api/v1/users/itineraries_controller.rb
+++ b/app/controllers/api/v1/users/itineraries_controller.rb
@@ -6,8 +6,7 @@ class Api::V1::Users::ItinerariesController < ApiController
     @new_itinerary.create_steps
     itinerary = @new_itinerary.itinerary
     base_time = itinerary.possible_routes[0].departure_time
-    CreateOtherPossibleRoute.new(itinerary.id, itinerary_params, base_time, 15).create_steps
-    possible_routes = itinerary.possible_routes
+    SequentialCalls.new(itinerary.id, itinerary_params, base_time, 3).create_possible_routes
     updated_itinerary = Itinerary.find(itinerary.id)
     render json: updated_itinerary.possible_routes
   end

--- a/app/models/sequential_calls.rb
+++ b/app/models/sequential_calls.rb
@@ -1,0 +1,18 @@
+class SequentialCalls
+  attr_reader :itinerary_id, :itinerary_attrs, :base_time, :repetitions
+
+  def initialize(itinerary_id, itinerary_attrs, base_time, repetitions)
+    @itinerary_id = itinerary_id
+    @itinerary_attrs = itinerary_attrs
+    @base_time = base_time
+    @repetitions = repetitions
+  end
+
+  def create_possible_routes
+    additional_time = 15
+    repetitions.times do
+      CreateOtherPossibleRoute.new(itinerary_id, itinerary_attrs, base_time, additional_time).create_steps
+      additional_time += 15
+    end
+  end
+end

--- a/spec/requests/api/v1/itineraries/post_itinerary_endpoint_spec.rb
+++ b/spec/requests/api/v1/itineraries/post_itinerary_endpoint_spec.rb
@@ -33,8 +33,10 @@ describe 'POST /api/v1/users/:id/itineraries' do
     expect(response).to be_successful
 
     new_itineraries = JSON.parse(response.body, symbolize_names:true)
-    expect(new_itineraries.length).to eq(2)
+    expect(new_itineraries.length).to eq(4)
     expect(new_itineraries[0][:departure_time]).to eq("5:06pm")
     expect(new_itineraries[1][:departure_time]).to eq("5:21pm")
+    expect(new_itineraries[2][:departure_time]).to eq("5:36pm")
+    expect(new_itineraries[3][:departure_time]).to eq("5:51pm")
   end
 end


### PR DESCRIPTION
#### Changes Proposed:
* Adds intermediary PORO called SequentialCalls to make a certain number of other possible routes.
* Updates POST itineraries endpoint to expect 4 possible routes.

#### Fixes Made:
*

#### Testing:
* Tested on RSPEC? Yes
* All tests passing? Yes
#### Mentions:
