### PR TITLE
Adds a skeleton of a rake file.

### DIFF
--- a/lib/tasks/delete_possible_routes.rake
+++ b/lib/tasks/delete_possible_routes.rake
@@ -1,0 +1,7 @@
+namespace :possible_routes do
+
+  desc 'deletes all possible routes from favorites'
+  task :delete_all => :environment do
+    
+  end
+end

--- a/spec/requests/api/v1/favorite_itineraries/user_can_get_favorite_itinerary_spec.rb
+++ b/spec/requests/api/v1/favorite_itineraries/user_can_get_favorite_itinerary_spec.rb
@@ -12,9 +12,9 @@ describe "GET /api/v1/users/:uid/favorites" do
     step_2 = create(:step, possible_route_id: possible_route_1.id)
     step_3 = create(:step, possible_route_id: possible_route_2.id)
     step_4 = create(:step, possible_route_id: possible_route_2.id)
-    
+
     get "/api/v1/users/#{user.uid}/favorites"
-    
+
     expect(response).to be_successful
     favorite_itineraries = JSON.parse(response.body, symbolize_names: true)
     expect(favorite_itineraries[0][:title]).to eq('commute')
@@ -25,7 +25,7 @@ describe "GET /api/v1/users/:uid/favorites" do
 end
 
 describe "GET /api/v1/users/:uid/favorites/:favorite_id" do
-  it "can get a single favorite itinerary" do
+  it "can get a single favorite itinerary", vcr: true do
     user = create(:user, uid: 'abc123')
 
     fav_itinerary_1 = user.itineraries.create(start_address: "100 W. 14th Pkwy Denver CO 80204", end_address: "1331 17th St Denver CO", favorite: true, title: 'commute')
@@ -34,13 +34,13 @@ describe "GET /api/v1/users/:uid/favorites/:favorite_id" do
     possible_route_2 = create(:possible_route, itinerary_id: fav_itinerary_2.id)
     step_1 = create(:step, possible_route_id: possible_route_2.id)
     step_2 = create(:step, possible_route_id: possible_route_2.id)
-    
+
     get "/api/v1/users/#{user.uid}/favorites/#{fav_itinerary_2.id}"
 
     expect(response).to be_successful
-    favorite = JSON.parse(response.body, symbolize_names: true)
-    expect(favorite[:itinerary_id]).to eq(fav_itinerary_2.id)
-    expect(favorite[:title]).to eq(fav_itinerary_2.title)
-    expect(favorite[:steps].length).to eq(2)
+    possible_routes = JSON.parse(response.body, symbolize_names: true)
+    expect(possible_routes.length).to eq(4)
+    expect(possible_routes[0][:start_address]).to eq(fav_itinerary_2.start_address)
+    expect(possible_routes[0][:end_address]).to eq(fav_itinerary_2.end_address)
   end
 end


### PR DESCRIPTION
#### Changes Proposed:
* Adds a new possible_route finder for existing favorites.
* Adds the skeleton of a rakefile that we will use to delete all possible routes prior to refinding the possible routes for favorites.

#### Fixes Made:
* Adjusts GET /favorites/itinerary_id test to account for the fact that we are now making api calls for this action.

#### Testing:
* Tested on RSPEC? Yes
* All tests passing? Yes

#### Mentions:
@jamisonordway Considering the revised expected behavior, we actually do need to use cassettes on this test!