### PR TITLE
Refactors favorites to return more concise information, closes #52

### DIFF
--- a/app/controllers/api/v1/users/favorite_itineraries_controller.rb
+++ b/app/controllers/api/v1/users/favorite_itineraries_controller.rb
@@ -5,23 +5,24 @@ class Api::V1::Users::FavoriteItinerariesController < ApiController
     itinerary = user.itineraries.find(params[:itinerary_id])
     itinerary.update(favorite: true)
     itinerary.update(favorite_params)
-    render json: itinerary.possible_routes
+    render json: itinerary
   end
 
   def index
     user = User.find_by(uid: params[:uid])
     user_id = user.id
-    favorites = user.possible_routes.joins(:itinerary).where('itineraries.favorite = true')
+    favorites = user.itineraries.where(favorite: true)
     render json: favorites
   end
 
   def show
     user = User.find_by(uid: params[:uid])
+    base_time = DateTime.now.strftime("%l:%M%P")
     itinerary = Itinerary.find(params[:itinerary_id])
     SequentialCalls.new(
       itinerary.id,
       { start_address: itinerary.start_address, end_address: itinerary.end_address },
-      DateTime.now.strftime("%l:%M%P"),
+      base_time,
       4
     ).create_possible_routes
     favorite = user.possible_routes

--- a/app/serializers/itinerary_serializer.rb
+++ b/app/serializers/itinerary_serializer.rb
@@ -1,4 +1,3 @@
 class ItinerarySerializer < ActiveModel::Serializer
-  attributes :id, :start_address, :end_address, :favorite, :title
-  has_many :possible_routes
+  attributes :id, :start_address, :end_address, :favorite
 end

--- a/spec/requests/api/v1/favorite_itineraries/user_can_edit_favorite_itinerary_spec.rb
+++ b/spec/requests/api/v1/favorite_itineraries/user_can_edit_favorite_itinerary_spec.rb
@@ -15,7 +15,7 @@ describe 'PUT /api/v1/users/:id/favorite_itinerary' do
     put "/api/v1/users/#{user.uid}/favorites/#{fav_itinerary_2.id}", params: {title: '7th Circle'}
     edited = JSON.parse(response.body, symbolize_names: true)
     expect(response).to be_successful
-    expect(edited[:title]).to eq('7th Circle')
-    expect(edited[:title]).to_not eq('concert')
+    expect(edited[:start_address]).to eq(fav_itinerary_2.start_address)
+    expect(edited[:end_address]).to eq(fav_itinerary_2.end_address)
   end
 end

--- a/spec/requests/api/v1/favorite_itineraries/user_can_get_favorite_itinerary_spec.rb
+++ b/spec/requests/api/v1/favorite_itineraries/user_can_get_favorite_itinerary_spec.rb
@@ -17,10 +17,10 @@ describe "GET /api/v1/users/:uid/favorites" do
 
     expect(response).to be_successful
     favorite_itineraries = JSON.parse(response.body, symbolize_names: true)
-    expect(favorite_itineraries[0][:title]).to eq('commute')
-    expect(favorite_itineraries[1][:title]).to eq('concert')
-    expect(favorite_itineraries[0][:steps].length).to eq(2)
-    expect(favorite_itineraries[1][:steps].length).to eq(2)
+    expect(favorite_itineraries[0][:start_address]).to eq(fav_itinerary_1.start_address)
+    expect(favorite_itineraries[0][:end_address]).to eq(fav_itinerary_1.end_address)
+    expect(favorite_itineraries[1][:start_address]).to eq(fav_itinerary_2.start_address)
+    expect(favorite_itineraries[1][:end_address]).to eq(fav_itinerary_2.end_address)
   end
 end
 

--- a/spec/requests/api/v1/favorite_itineraries/user_can_post_favorite_itinerary_spec.rb
+++ b/spec/requests/api/v1/favorite_itineraries/user_can_post_favorite_itinerary_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'POST /api/v1/users/:id/favorite_itineraries' do
   it 'can post a user\'s favorite itinerary' do
     user = create(:user, uid: 'abc123')
-  
+
     itinerary = user.itineraries.create( start_address: "100 W. 14th Pkwy Denver CO 80204", end_address: "1331 17th St Denver CO")
     possible_route = create(:possible_route, itinerary_id: itinerary.id)
     post "/api/v1/users/#{user.uid}/itineraries/#{itinerary.id}", params: { title: "Title" }
@@ -11,7 +11,8 @@ describe 'POST /api/v1/users/:id/favorite_itineraries' do
     expect(response).to be_successful
 
     new_favorite = JSON.parse(response.body, symbolize_names: true)
-    expect(new_favorite[0][:title]).to eq("Title")
-    expect(new_favorite[0][:favorite]).to eq(true)
+    expect(new_favorite[:start_address]).to eq(itinerary.start_address)
+    expect(new_favorite[:end_address]).to eq(itinerary.end_address)
+    expect(new_favorite[:favorite]).to eq(true)
   end
 end


### PR DESCRIPTION
#### Changes Proposed:
* Updates favorites index to return itinerary object instead of possible routes
* Updates favorites create to return itinerary object instead of possible routes
* Updates itinerary serializer to no longer return steps
* Updates tests to account for new expected behavior.

#### Fixes Made:
* Above changes made per front-end team's desired return-objects

#### Testing:
* Tested on RSPEC? Yes
* All tests passing? Yes

#### Mentions:
@jamisonordway I changed the favorites controller to reflect the front-end team's desired return values. It seems that they weren't using favorites for anything other than the id, start_address, and end_address, so they didn't need the entire possible routes object.
