### PR TITLE
Attempts to fix the time issue that was occurring with get favorites, closes #55

### DIFF
--- a/app/controllers/api/v1/users/favorite_itineraries_controller.rb
+++ b/app/controllers/api/v1/users/favorite_itineraries_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::Users::FavoriteItinerariesController < ApiController
 
   def show
     user = User.find_by(uid: params[:uid])
-    base_time = DateTime.now.strftime("%l:%M%P")
+    base_time = Time.zone.now.strftime("%l:%M%P")
     itinerary = Itinerary.find(params[:itinerary_id])
     SequentialCalls.new(
       itinerary.id,

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ module RtdRailsApi
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
-  
+
     config.action_dispatch.default_headers = {
       'Access-Control-Allow-Origin' => 'https://rtd-mobile.herokuapp.com/',
       'Access-Control-Request-Method' => %w{GET POST PATCH DELETE OPTIONS}.join(",")
@@ -45,5 +45,7 @@ module RtdRailsApi
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.time_zone = 'Mountain Time (US & Canada)'
   end
 end


### PR DESCRIPTION
#### Changes Proposed:
* Adds mountain time as the app time zone and uses Time.zone.now in the favorites#show action in order to ensure that we are not getting UTC time.

#### Fixes Made:
* get favorites timezone issue.

#### Testing:
* Tested on RSPEC? Yes
* All tests passing? Yes

#### Mentions: @jamisonordway Regarding the weird issue where the favorites#show was working locally but not in production I realized that Heroku was using UTC for datetime.now. Hopefully by declaring the time zone in the config and using Time.zone.now we don't mess up other places where we are expecting DateTime to work using UTC as its base.
