### PR TITLE
Adjusts login to return users favorites and recent searches

### DIFF
--- a/app/controllers/api/v1/users/favorite_itineraries_controller.rb
+++ b/app/controllers/api/v1/users/favorite_itineraries_controller.rb
@@ -10,7 +10,6 @@ class Api::V1::Users::FavoriteItinerariesController < ApiController
 
   def index
     user = User.find_by(uid: params[:uid])
-    user_id = user.id
     favorites = user.itineraries.where(favorite: true)
     render json: favorites
   end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -6,8 +6,12 @@ class Api::V1::UsersController < ApplicationController
   end
 
   def show
-    user = User.find_by(uid: params[:uid])
-    render json: user
+    if User.find_by(uid: params[:uid]).present?
+      info = GetUserInfo.new(params[:uid]).show_all
+      render json: info
+    else
+      render status: 404
+    end
   end
 
   private

--- a/app/models/create_favorite_trips.rb
+++ b/app/models/create_favorite_trips.rb
@@ -1,9 +1,0 @@
-class CreateFavoriteTrips < CreateWholeTrip
-
-
-  def initialize(user_id, attrs)
-    @user_id = attrs[:id]
-    binding.pry
-  end
-
-end

--- a/app/models/get_user_info.rb
+++ b/app/models/get_user_info.rb
@@ -1,0 +1,23 @@
+class GetUserInfo
+  attr_reader :user
+
+  def initialize(user_id)
+    @user = User.find_by(uid: user_id)
+  end
+
+  def show_all
+    {
+      user: user,
+      favorites: get_favorites,
+      recent_searches: get_recent_searches
+    }
+  end
+
+  def get_recent_searches
+    user.itineraries.where(favorite: false).last(5)
+  end
+
+  def get_favorites
+    user.itineraries.where(favorite: true)
+  end
+end

--- a/spec/requests/api/v1/users/get_user_spec.rb
+++ b/spec/requests/api/v1/users/get_user_spec.rb
@@ -3,14 +3,29 @@ require 'rails_helper'
 describe 'GET /users/:uid' do
   it 'should be able to return a user by uid' do
     user = create(:user, uid: 'abc123')
+    favorite = user.itineraries.create(
+      start_address: '12 Cedar Place, Denver, CO',
+      end_address: '1331 17th St, Denver, CO',
+      favorite: true
+    )
+    recent_search = user.itineraries.create(
+      start_address: 'Denver International Airport',
+      end_address: '12 Cedar Place, Denver, CO'
+    )
 
     get "/api/v1/users/#{user.uid}"
 
     expect(response).to be_successful
 
-    new_user = JSON.parse(response.body, symbolize_names: true)
-    expect(new_user[:username]).to eq(user.username)
-    expect(new_user[:email]).to eq(user.email)
-    expect(new_user[:uid]).to eq('abc123')
+    info = JSON.parse(response.body, symbolize_names: true)
+    expect(info[:user][:username]).to eq(user.username)
+    expect(info[:user][:email]).to eq(user.email)
+    expect(info[:user][:uid]).to eq('abc123')
+    expect(info[:favorites][0][:start_address]).to eq(favorite.start_address)
+    expect(info[:favorites][0][:end_address]).to eq(favorite.end_address)
+    expect(info[:favorites][0][:favorite]).to eq(true)
+    expect(info[:recent_searches][0][:start_address]).to eq(recent_search.start_address)
+    expect(info[:recent_searches][0][:end_address]).to eq(recent_search.end_address)
+    expect(info[:recent_searches][0][:favorite]).to eq(false)
   end
 end


### PR DESCRIPTION
#### Changes Proposed:
* Creates Get User Info PORO so that we can return user info, favorites, and recent searches at once.
* Currently returns useless info such as created_at and updated_at because I don't think you can serialize a PORO. I tried but did not succeed. We can hand roll some serialization should it be necessary.

#### Fixes Made:
* Removed an unused assignment to variable
* Removed an unused PORO

#### Testing:
* Tested on RSPEC? Yes
* All tests passing? Yes

#### Mentions:
@jamisonordway , I made the changes that Quin requested. I used a PORO but it is not serialized. I also set up the object it returns to have the following keys: user, favorites, and recent_searches. Quin may want us to adjust this in the future or serialize that data somehow, but for now I just went with the path of least resistance.
